### PR TITLE
Update package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "splash-screen",
-  "version": "0.2.0",
+  "name": "@dynamods/splash-screen",
+  "version": "0.2.1",
   "description": "Splash Screen maintained by Dynamo Team@Autodesk",
   "author": "Autodesk Inc.",
   "license": "MIT",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = () => {
       app: './src/index.js',
     },
     output: {
-      path: path.join(__dirname, '/dist'),
+      path: path.join(__dirname, '/dist/build'),
       filename: 'index.bundle.js',
       clean: true,
     },


### PR DESCRIPTION
- Package publish was failing and I found we need to include npm scope as package name
- Add build folder under dist so we follow same folder structure as Notification Center package