### PR TITLE
DYN-5268-SplashScreen-NotLoadingFix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dynamods/splash-screen",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Splash Screen maintained by Dynamo Team@Autodesk",
   "author": "Autodesk Inc.",
   "license": "MIT",

--- a/public/index.html
+++ b/public/index.html
@@ -9,8 +9,8 @@
   <script>
     document.querySelector('body').style.overflow = 'hidden'
   </script>
-  <script>mainJs</script>
   <div id="root"></div>
+  <script>mainJs</script>
 </body>
 
 </html>


### PR DESCRIPTION
### Purpose
Fix for loading the SplashScreen in Dynamo at startup
When trying to load the splash screen in Dynamo was showing a blank screen, the problem was that due that the javascript code is inserted on runtime when loading the html page in WebView2 the javascript code was not finding the element "root", once I moved the root <div> above the <script> tag started to work correctly.
### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Fix for loading the SplashScreen in Dynamo at startup


### Reviewers

@QilongTang 

### FYIs
