### PR TITLE
[DYN-6353] Fix SignIn button title to reflect correct status when user is already signed in

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dynamods/splash-screen",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dynamods/splash-screen",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "license": "MIT",
       "dependencies": {
         "bootstrap": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dynamods/splash-screen",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Splash Screen maintained by Dynamo Team@Autodesk",
   "author": "Autodesk Inc.",
   "license": "MIT",

--- a/src/Static.js
+++ b/src/Static.js
@@ -49,7 +49,7 @@ class Static extends React.Component {
 
         <Row className='mt-3'>
         <button id='btnSignIn' className='primaryButton' onClick={this.signIn} tabIndex={2}>
-            {this.props.signInTitle}
+            {this.state.signInTitle}
           </button>
         </Row>
 


### PR DESCRIPTION
Fix a regression from previous PR.
Changing the variable source from props, to state, where it is being updated.

![ezgif com-crop](https://github.com/DynamoDS/SplashScreen/assets/32665108/2446857d-27e9-4e44-becd-c5bd6d50f179)
