### PR TITLE
DYN-6775 localizing tooltips splash screen

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -79,10 +79,10 @@ class App extends React.Component {
                     <Static
                       signInStatus={this.state.signInStatus}
                       signInTitle={this.state.signInTitle}
-                      signInToolTip={this.state.signInToolTip}
+                      signInTooltip={this.state.signInTooltip}
                       signingInTitle={this.state.signingInTitle}
                       signOutTitle={this.state.signOutTitle}
-                      signOutToolTip={this.state.signInToolTip}
+                      signOutTooltip={this.state.signOutTooltip}
                       welcomeToDynamoTitle={this.state.welcomeToDynamoTitle}
                       launchTitle={this.state.launchTitle}
                       showScreenAgainLabel={this.state.showScreenAgainLabel}
@@ -112,10 +112,10 @@ class App extends React.Component {
       importSettingsTitle: labels.importSettingsTitle,
       importSettingsTooltipDescription: labels.importSettingsTooltipDescription,
       signInTitle: labels.signInTitle,
-      signInToolTip: labels.signInToolTip,
+      signInTooltip: labels.signInTooltip,
       signingInTitle: labels.signingInTitle,
       signOutTitle: labels.signOutTitle,
-      signOutToolTip: labels.signOutToolTip
+      signOutTooltip: labels.signOutTooltip
     });
   }
 

--- a/src/Static.js
+++ b/src/Static.js
@@ -59,7 +59,7 @@ class Static extends React.Component {
 
         <Row className='mt-3'>
           <OverlayTrigger placement='right' overlay={
-            <Tooltip>{this.props.signInStatus ? this.props.signOutTooltip : this.props.signInTooltip}</Tooltip>
+            <Tooltip>{this.state.signInTooltip}</Tooltip>
           }>
             <button id='btnSignIn' className='primaryButton' onClick={this.signIn} tabIndex={2} >
               {this.state.signInTitle}

--- a/src/Static.js
+++ b/src/Static.js
@@ -59,7 +59,7 @@ class Static extends React.Component {
 
         <Row className='mt-3'>
           <OverlayTrigger placement='right' overlay={
-            <Tooltip>{this.state.signInTooltip}</Tooltip>
+            <Tooltip>{this.props.signInStatus ? this.props.signOutTooltip : this.props.signInTooltip}</Tooltip>
           }>
             <button id='btnSignIn' className='primaryButton' onClick={this.signIn} tabIndex={2} >
               {this.state.signInTitle}


### PR DESCRIPTION
Localization of tooltips in the SplashScreen button was not working due that the states had spelling problems then I did some changes and now the tooltips are shown in the expected language.